### PR TITLE
World tp menu fix

### DIFF
--- a/WorldTP/src/main/java/com/code12/worldtp/menues/AdvancedWorldTPMenu.java
+++ b/WorldTP/src/main/java/com/code12/worldtp/menues/AdvancedWorldTPMenu.java
@@ -19,8 +19,11 @@ public class AdvancedWorldTPMenu {
 
         int numberOfWorlds = plugin.getConfig().getStringList("menuGroupList").size();
         int numberOfSlots = 9;
-        for(int i=9; (i/numberOfWorlds)<1; i+=9){
-            numberOfSlots = i;
+
+        int j = 9;
+        while((j/numberOfWorlds) < 1){
+            j += 9;
+            numberOfSlots = j;
         }
 
         tpMenu = Bukkit.createInventory(null, numberOfSlots, "World Menu");

--- a/WorldTP/src/main/java/com/code12/worldtp/menues/WorldTPMenu.java
+++ b/WorldTP/src/main/java/com/code12/worldtp/menues/WorldTPMenu.java
@@ -28,8 +28,11 @@ public class WorldTPMenu{
         }
 
         int numberOfSlots = 9;
-        for(int i=9; (i/notAdminWorlds.size())<1; i+=9){
-            numberOfSlots = i;
+
+        int j = 9;
+        while((j/notAdminWorlds.size()) < 1){
+            j += 9;
+            numberOfSlots = j;
         }
 
         tpMenu = Bukkit.createInventory(null, numberOfSlots, "World Menu");


### PR DESCRIPTION
Fixed the bug where the WorldTP menu would cause an error because numberOfSlots was not big enough to hold all the worlds.